### PR TITLE
Enable user tracking even if RUM is disabled in magento admin

### DIFF
--- a/source/app/code/community/Yireo/NewRelic/Model/Observer.php
+++ b/source/app/code/community/Yireo/NewRelic/Model/Observer.php
@@ -209,8 +209,7 @@ class Yireo_NewRelic_Model_Observer
      */
     public function controllerActionPostdispatch($observer) 
     {
-        if (!$this->_isEnabled()
-                || !$this->_getHelper()->isUseRUM()){
+        if (!$this->_isEnabled()) {
             return $this;
         }
 


### PR DESCRIPTION
I don't know if I'm missing something here but my understanding of this user tracking method is that it shouldn't depend on the RUM feature being enabled or not.
